### PR TITLE
Add messaging for sunsetting Digitimate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,18 @@
 # Digitimate
 Service for confirming mobile numbers
 
-See http://digitimate.com/ for more info
+## Note: We are sunsetting Digitimate on Monday, July 9, 2018.
+
+On July 9, 2018, we are sunsetting Digitimate. This is over 180 days from the announcement (on January 9), which we believe is ample advance notice for developers to find time to gracefully migrate off of Digitimate.
+
+**Developers who are already using Digitimate:** We will help you migrate to another SMS confirmation service by letting you export the data associated with the developer email address you used with Digitimate.
+
+You either can run Digitimate yourself (the code will stay open-source on July 9), which requires Node.js, RethinkDB, and a Twilio account, or you can use another SMS confirmation service, such as building your own that connects to an SMS service like Twilio.
+
+**Developers who aren't already using Digitimate:** We recommend that you choose another service today so you don't have to migrate so soon.
+
+**Data policy:** After July 9, the Digitimate service will no longer be online. We may continue to allow developers to export data associated with their developer email addresses for a couple of weeks afterwards. After that, we'll turn off Digitimate and terminate the Node.js servers, RethinkDB server, and disks used by those servers.
+
+## About
+
+See http://digitimate.com/ for more info.

--- a/server/site/homepage.html
+++ b/server/site/homepage.html
@@ -237,7 +237,7 @@
     render: function () {
       return (
         <div className="jumbotron">
-          <h1>Digitimate</h1>
+          <h1>Digitimate (sunsetting)</h1>
           <h3>The legitimately easiest way to verify user{"'"}s mobile numbers via SMS in two easy steps</h3>
         </div>
       );
@@ -248,6 +248,11 @@
     render: function () {
       return (
         <div>
+        <div className="row">
+          <h2>Note: Digitimate is sunsetting on July 9, 2018.</h2>
+          <p>If you're a developer using Digitimate, we will help you migrate to another SMS confirmation service by letting you export the data associated with the developer email address you used with Digitimate.</p>
+          <p>You either can run Digitimate yourself (the code will stay open-source on July 9), which requires Node.js, RethinkDB, and a Twilio account, or you can use another SMS confirmation service, such as building your own that connects to an SMS service like Twilio.</p>
+        </div>
         <div className="row">
           <h2>No signup required. Free. Open source.</h2>
           <p>You don{"'"}t need to create an account or signup anywhere to get started; just include your e-mail


### PR DESCRIPTION
We're planning on sunsetting Digitimate gracefully and want developers using it to smoothly migrate to another service. First we'll communicate to developers about this change and give them at least 180 days to plan. This commit adds visible messaging to the GitHub README and the homepage to start raising awareness.

We'll also need to build an API endpoint for developers to export data for the developer email address they used.